### PR TITLE
chore(fxa): add tests_per_second measures

### DIFF
--- a/views/fxa.view.lkml
+++ b/views/fxa.view.lkml
@@ -112,7 +112,7 @@ view: fxa {
             AND sub_r.Timestamp BETWEEN TIMESTAMP_SUB(r.Timestamp, INTERVAL 90 DAY) AND r.Timestamp)
         AS tests_per_second_90_rolling,
 
-        (SELECT AVG(SAFE_DIVIDE(sub_r.Total, sub_r.`Execution Time`) * 60)
+        (SELECT AVG(SAFE_DIVIDE(SAFE_DIVIDE(sub_r.Total, sub_r.`Execution Time`), 60))
          FROM `test_metrics.fxa_suite_results` sub_r
          WHERE sub_r.Repository = r.Repository
            AND sub_r.Workflow = r.Workflow

--- a/views/fxa.view.lkml
+++ b/views/fxa.view.lkml
@@ -112,7 +112,7 @@ view: fxa {
             AND sub_r.Timestamp BETWEEN TIMESTAMP_SUB(r.Timestamp, INTERVAL 90 DAY) AND r.Timestamp)
         AS tests_per_second_90_rolling,
 
-        (SELECT AVG(SAFE_DIVIDE(SAFE_DIVIDE(sub_r.Total, sub_r.`Execution Time`), 60))
+        (SELECT AVG(SAFE_MULTIPLY(SAFE_DIVIDE(sub_r.Total, sub_r.`Execution Time`), 60))
          FROM `test_metrics.fxa_suite_results` sub_r
          WHERE sub_r.Repository = r.Repository
            AND sub_r.Workflow = r.Workflow
@@ -352,7 +352,7 @@ view: fxa {
   measure: tests_per_minute {
     type: number
     value_format_name: "decimal_2"
-    sql: SAFE_DIVIDE(SAFE_DIVIDE(${total}, ${execution_time}), 60) ;;
+    sql: SAFE_MULTIPLY(SAFE_DIVIDE(${total}, ${execution_time}), 60) ;;
     label: "Tests per minute"
     description: "Number of tests executed per minute"
   }


### PR DESCRIPTION
⚠️ DO NOT MERGE

This is for code review, but merge should happen in Looker

Because:
- FXA wants a metric of how many tests we execute per second or minute for visibility into test efficiency

This Commit:
- Adds a measure for tests_per_minute
- Adds a measure for 90-day-rolling avg tests/sec & tests/min